### PR TITLE
Allow to set custom cache timeout

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -121,6 +121,13 @@ If you find yourself in a situation where you need to use the features of django
 		class Product(models.Model):
 		    name = models.TextField(verbose_name=translator_lazy('a_key', 'custom_translation'))
 
+Settings
+-------------
+Customize the translator in your settings.py file with these settings::
+
+	DJANGO_TRANSLATOR_CACHE_TIMEOUT = timeout in seconds, if not set defaults to DEFAULT_TIMEOUT, which is either the CACHES['TIMEOUT'] setting or 300 (5 minutes)
+
+
 Project Home
 ------------
 https://github.com/dreipol/django-translator

--- a/translator/util.py
+++ b/translator/util.py
@@ -4,6 +4,7 @@ import logging
 
 import six
 from django.conf import settings
+from django.core.cache.backends.base import DEFAULT_TIMEOUT
 from django.db.utils import OperationalError, ProgrammingError
 from django.utils.functional import lazy
 from django.utils.module_loading import import_string
@@ -11,6 +12,7 @@ from django.utils.safestring import mark_safe
 
 from translator.context_processors import DJANGO_TRANSLATOR_MODELS
 
+CACHE_TIMEOUT = getattr(settings, "DJANGO_TRANSLATOR_CACHE_TIMEOUT", DEFAULT_TIMEOUT)
 
 def get_translation_for_key(item, model_class=None):
     from django.core.cache import cache
@@ -37,11 +39,7 @@ def get_translation_for_key(item, model_class=None):
                     result.save()
                     result = result.description
 
-                custom_cache_timeout = getattr(settings, "DJANGO_TRANSLATOR_CACHE_TIMEOUT")
-                if custom_cache_timeout:
-                    cache.set(key, result, timeout=custom_cache_timeout)
-                else:
-                    cache.set(key, result)
+                cache.set(key, result, timeout=CACHE_TIMEOUT)
         except (OperationalError, ProgrammingError):
             logging.getLogger(__name__).info("Unable to get translation for {0}".format(item), )
             result = item


### PR DESCRIPTION
It would be nice, if we could customize the cache timeout in a django setting.
Otherwise the default cache timeout will always be used.
But the translation keys could, in my opinion, be cached for a long time, which the default cache timeout must not be.