### PR TITLE
Add cache key prefix

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -125,6 +125,7 @@ Settings
 -------------
 Customize the translator in your settings.py file with these settings::
 
+	DJANGO_TRANSLATOR_CACHE_PREFIX = cache key prefix, if not set defaults to "translator:"
 	DJANGO_TRANSLATOR_CACHE_TIMEOUT = timeout in seconds, if not set defaults to DEFAULT_TIMEOUT, which is either the CACHES['TIMEOUT'] setting or 300 (5 minutes)
 
 

--- a/translator/util.py
+++ b/translator/util.py
@@ -11,6 +11,8 @@ from django.utils.safestring import mark_safe
 
 from translator.context_processors import DJANGO_TRANSLATOR_MODELS
 
+
+CACHE_PREFIX = getattr(settings, "DJANGO_TRANSLATOR_CACHE_PREFIX", "translator:")
 CACHE_TIMEOUT = getattr(settings, "DJANGO_TRANSLATOR_CACHE_TIMEOUT", DEFAULT_TIMEOUT)
 TRANSLATOR_IS_ENABLED = getattr(settings, "DJANGO_TRANSLATOR_ENABLED", True)
 
@@ -52,7 +54,7 @@ def get_translation_for_key(item, model_class=None):
 
 def get_key(lang, item, prefix):
     item = hashlib.sha256(item.encode('utf-8')).hexdigest()
-    key = u'{0}-{1}-{2}'.format(lang, prefix, item)
+    key = u'{}{0}-{1}-{2}'.format(CACHE_PREFIX, lang, prefix, item)
     return key
 
 


### PR DESCRIPTION
This is just a nice to have feature 😄 

I think all the translation keys should have a namespace (e.g. "translator:") 

I took the idea from: https://django-constance.readthedocs.io/en/latest/backends.html#constance-redis-prefix
And its also what redis recommend: https://redis.com/blog/5-key-takeaways-for-developing-with-redis/

we could even go as far and make the "language" part of the cache key its own namespace